### PR TITLE
Updates to sectioning logic

### DIFF
--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -432,11 +432,13 @@ class MediaWikiPage(object):
                 Side effect is to also pull the content which can be slow
             Note:
                 This is a parsing operation and not part of the standard API'''
-        section = '== {0} =='.format(section_title)
+
+        section_regexp = '\n==* {} ==*\n'.format(section_title)
         try:
             content = self.content
-            index = content.index(section) + len(section)
-        except ValueError:
+            match = re.search(section_regexp, content)
+            index = match.span()[1]
+        except (ValueError, AttributeError):
             return None
 
         try:

--- a/mediawiki/utilities.py
+++ b/mediawiki/utilities.py
@@ -90,3 +90,20 @@ def is_relative_url(url):
         # either 'http(s)://...' or '//cdn...' and therefore absolute
         return False
     return True
+
+
+def set_key_path(_dict, path, value):
+    node = _dict
+    for key in path[:-1]:
+        node = node[key]
+
+    node[path[-1]] = value
+
+
+def get_key_path(_dict, key_path, delimiter='.'):
+    path = key_path.split(delimiter)
+    node = _dict
+    for key in path:
+        node = node[key]
+
+    return node

--- a/mediawiki/utilities.py
+++ b/mediawiki/utilities.py
@@ -98,12 +98,3 @@ def set_key_path(_dict, path, value):
         node = node[key]
 
     node[path[-1]] = value
-
-
-def get_key_path(_dict, key_path, delimiter='.'):
-    path = key_path.split(delimiter)
-    node = _dict
-    for key in path:
-        node = node[key]
-
-    return node


### PR DESCRIPTION
- Use regular expressions to correctly extract section content
    - Sub-sub sections were always blank because previous logic looked for `== {title} ==` rather than `==* {title} ==*`
- Add methods to parse sections in a nested fashion (returned in an OrderedDict)

For "New York City" we get:

```python
OrderedDict([(u'History',
              OrderedDict([(u'Etymology', OrderedDict()),
                           (u'Early_history', OrderedDict()),
                           (u'Dutch_rule', OrderedDict()),
                           (u'English_rule', OrderedDict()),
                           (u'American_Revolution', OrderedDict()),
                           (u'Nineteenth_century', OrderedDict()),
                           (u'Modern_history', OrderedDict())])),
             (u'Geography',
              OrderedDict([(u'Cityscapes', OrderedDict()),
                           (u'Architecture', OrderedDict()),
                           (u'Boroughs', OrderedDict()),
                           (u'Climate', OrderedDict()),
                           (u'Parks',
                            OrderedDict([(u'National_parks', OrderedDict()),
                                         (u'State_parks', OrderedDict()),
                                         (u'City_parks', OrderedDict())])),
                           (u'Military_installations', OrderedDict())])),
             (u'Demographics',
              OrderedDict([(u'Population_density', OrderedDict()),
                           (u'Race_and_ethnicity', OrderedDict()),
                           (u'Sexual_orientation_and_gender_identity',
                            OrderedDict([(u'Transgender_contribution',
                                          OrderedDict())])),
                           (u'Religion', OrderedDict()),
                           (u'Wealth_and_income_disparity', OrderedDict())])),
             (u'Economy',
              OrderedDict([(u'City_economic_overview', OrderedDict()),
                           (u'Wall_Street', OrderedDict()),
                           (u'Silicon_Alley', OrderedDict()),
                           (u'Tourism', OrderedDict()),
                           (u'Media_and_entertainment', OrderedDict())])),
             (u'Education_and_scholarly_activity',
              OrderedDict([(u'Primary_and_secondary_education', OrderedDict()),
                           (u'Higher_education_and_research',
                            OrderedDict())])),
             (u'Human_resources',
              OrderedDict([(u'Public_health', OrderedDict()),
                           (u'Public_safety',
                            OrderedDict([(u'Police_and_law_enforcement',
                                          OrderedDict()),
                                         (u'Firefighting', OrderedDict())])),
                           (u'Public_library_system', OrderedDict())])),
             (u'Culture_and_contemporary_life',
              OrderedDict([(u'Arts',
                            OrderedDict([(u'Performing_arts', OrderedDict()),
                                         (u'Visual_arts', OrderedDict())])),
                           (u'Cuisine', OrderedDict()),
                           (u'Parades', OrderedDict()),
                           (u'Accent_and_dialect', OrderedDict()),
                           (u'Sports', OrderedDict())])),
             (u'Transportation',
              OrderedDict([(u'Rapid_transit',
                            OrderedDict([(u'Rail', OrderedDict()),
                                         (u'Buses', OrderedDict())])),
                           (u'Air', OrderedDict()),
                           (u'Ferries', OrderedDict()),
                           (u'Taxis,_transport_startups,_and_trams',
                            OrderedDict()),
                           (u'Streets_and_highways',
                            OrderedDict([(u'River_crossings',
                                          OrderedDict())]))])),
             (u'Environment',
              OrderedDict([(u'Environmental_impact_reduction', OrderedDict()),
                           (u'Water_purity_and_availability', OrderedDict()),
                           (u'Environmental_revitalization', OrderedDict())])),
             (u'Government_and_politics',
              OrderedDict([(u'Government', OrderedDict()),
                           (u'Politics', OrderedDict())])),
             (u'Notable_people', OrderedDict()),
             (u'Global_outreach', OrderedDict()),
             (u'Notes', OrderedDict()),
             (u'References', OrderedDict()),
             (u'Further_reading', OrderedDict()),
             (u'External_links', OrderedDict())])
```

Todo 
- [ ] Add docs for the nested_sections method

@smaskell @Pravalikaavvaru