### PR TITLE
Use `line` instead of `anchor` for names

### DIFF
--- a/mediawiki/mediawikipage.py
+++ b/mediawiki/mediawikipage.py
@@ -425,7 +425,7 @@ class MediaWikiPage(object):
         previous_level = None
         for section in sections:
 
-            name = section['anchor']
+            name = section['line']
             level = int(section['level'])
 
             if previous_level is not None and level <= previous_level:


### PR DESCRIPTION
- it should have been line from the get-go.

anchor: `Dutch_rule`, `Early_history` etc
line: `Dutch rule`, `Early history`

snippet of response from Wikipedia API:

```json
"sections": [
            {
                "toclevel": 2,
                "level": "3",
                "line": "Dutch rule",
                "number": "1.3",
                "index": "4",
                "fromtitle": "New_York_City",
                "byteoffset": 46211,
                "anchor": "Dutch_rule"
            },
            ...
```
@smaskell @Pravalikaavvaru